### PR TITLE
Add ca-certificates.crt back to MANIFEST.in to fix curl issues when installing via `install` rather than `develop`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ recursive-include demos *.py *.yaml *.html *.css *.js *.xml *.sql README
 recursive-include docs *
 prune docs/build
 include tornado/speedups.c
+include tornado/ca-certificates.crt
 include tornado/test/README
 include tornado/test/csv_translations/fr_FR.csv
 include tornado/test/gettext_translations/fr_FR/LC_MESSAGES/tornado_test.mo


### PR DESCRIPTION
`ca-certificates.crt` was only getting included if you did an editable install, not a regular install and if it didn't exist, any kind of curl would fail.